### PR TITLE
refactor: formdata to json

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -30,18 +30,13 @@ const docTemplate = `{
                 "summary": "登录",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名或邮箱",
-                        "name": "username",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
+                        "description": "登录凭据",
+                        "name": "adminLoginParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminLoginParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -92,31 +87,13 @@ const docTemplate = `{
                 "summary": "更新站点信息",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "站点名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点图标(base64格式)",
-                        "name": "icon",
-                        "in": "formData"
+                        "description": "站点信息",
+                        "name": "adminSiteUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminSiteUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -322,25 +299,13 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "文章的标题",
-                        "name": "title",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章的描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章的内容",
-                        "name": "content",
-                        "in": "formData",
-                        "required": true
+                        "description": "文章更新参数",
+                        "name": "articleUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ArticleUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -384,25 +349,13 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "文章标题",
-                        "name": "title",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章内容",
-                        "name": "content",
-                        "in": "formData",
-                        "required": true
+                        "description": "文章参数",
+                        "name": "articleAddParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ArticleAddParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -488,31 +441,13 @@ const docTemplate = `{
                 "summary": "添加友情链接",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "图标URL",
-                        "name": "avatar",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "描述",
-                        "name": "desc",
-                        "in": "formData"
+                        "description": "友情链接信息",
+                        "name": "friendAddParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.FriendAddParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -612,44 +547,13 @@ const docTemplate = `{
                 "summary": "更新友情链接",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "友情链接的ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "图标URL",
-                        "name": "avatar",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "描述",
-                        "name": "desc",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "是否可见",
-                        "name": "visible",
-                        "in": "formData"
+                        "description": "更新友情链接参数",
+                        "name": "friendUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.FriendUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -730,64 +634,25 @@ const docTemplate = `{
         "/init": {
             "post": {
                 "description": "使用给定的参数初始化站点",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "站点管理"
                 ],
                 "summary": "初始化站点",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名",
-                        "name": "username",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "昵称",
-                        "name": "nickname",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "邮箱",
-                        "name": "email",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点描述",
-                        "name": "desc",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点图标(base64格式)",
-                        "name": "icon",
-                        "in": "formData"
+                        "description": "初始化参数",
+                        "name": "initParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.InitParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -873,32 +738,13 @@ const docTemplate = `{
                 "summary": "更新用户信息",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名",
-                        "name": "username",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "昵称",
-                        "name": "nickname",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "邮箱",
-                        "name": "email",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
+                        "description": "用户信息",
+                        "name": "adminUserUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminUserUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -972,10 +818,122 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.AdminLoginParams": {
+            "type": "object",
+            "required": [
+                "password",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "handler.AdminLoginResp": {
             "type": "object",
             "properties": {
                 "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.AdminSiteUpdateParams": {
+            "type": "object",
+            "required": [
+                "desc",
+                "name",
+                "url"
+            ],
+            "properties": {
+                "desc": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.AdminUserUpdateParams": {
+            "type": "object",
+            "required": [
+                "email",
+                "nickname",
+                "password",
+                "username"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 2
+                },
+                "password": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 6
+                },
+                "username": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 3
+                }
+            }
+        },
+        "handler.ArticleAddParams": {
+            "type": "object",
+            "required": [
+                "content",
+                "desc",
+                "slug",
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.ArticleUpdateParams": {
+            "type": "object",
+            "required": [
+                "content",
+                "desc",
+                "slug",
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -994,6 +952,30 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.FriendAddParams": {
+            "type": "object",
+            "required": [
+                "avatar",
+                "name",
+                "url"
+            ],
+            "properties": {
+                "avatar": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 32
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "handler.FriendListResp": {
             "type": "object",
             "properties": {
@@ -1005,6 +987,63 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.Friend"
                     }
+                }
+            }
+        },
+        "handler.FriendUpdateParams": {
+            "type": "object",
+            "properties": {
+                "avatar": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "visible": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "handler.InitParams": {
+            "type": "object",
+            "required": [
+                "email",
+                "name",
+                "nickname",
+                "password",
+                "url",
+                "username"
+            ],
+            "properties": {
+                "desc": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -23,18 +23,13 @@
                 "summary": "登录",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名或邮箱",
-                        "name": "username",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
+                        "description": "登录凭据",
+                        "name": "adminLoginParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminLoginParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -85,31 +80,13 @@
                 "summary": "更新站点信息",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "站点名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点图标(base64格式)",
-                        "name": "icon",
-                        "in": "formData"
+                        "description": "站点信息",
+                        "name": "adminSiteUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminSiteUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -315,25 +292,13 @@
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "文章的标题",
-                        "name": "title",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章的描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章的内容",
-                        "name": "content",
-                        "in": "formData",
-                        "required": true
+                        "description": "文章更新参数",
+                        "name": "articleUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ArticleUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -377,25 +342,13 @@
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "文章标题",
-                        "name": "title",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章描述",
-                        "name": "desc",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "文章内容",
-                        "name": "content",
-                        "in": "formData",
-                        "required": true
+                        "description": "文章参数",
+                        "name": "articleAddParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ArticleAddParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -481,31 +434,13 @@
                 "summary": "添加友情链接",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "图标URL",
-                        "name": "avatar",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "描述",
-                        "name": "desc",
-                        "in": "formData"
+                        "description": "友情链接信息",
+                        "name": "friendAddParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.FriendAddParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -605,44 +540,13 @@
                 "summary": "更新友情链接",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "友情链接的ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "图标URL",
-                        "name": "avatar",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "描述",
-                        "name": "desc",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "是否可见",
-                        "name": "visible",
-                        "in": "formData"
+                        "description": "更新友情链接参数",
+                        "name": "friendUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.FriendUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -723,64 +627,25 @@
         "/init": {
             "post": {
                 "description": "使用给定的参数初始化站点",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "站点管理"
                 ],
                 "summary": "初始化站点",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名",
-                        "name": "username",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "昵称",
-                        "name": "nickname",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "邮箱",
-                        "name": "email",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点名称",
-                        "name": "name",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点URL",
-                        "name": "url",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点描述",
-                        "name": "desc",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "站点图标(base64格式)",
-                        "name": "icon",
-                        "in": "formData"
+                        "description": "初始化参数",
+                        "name": "initParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.InitParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -866,32 +731,13 @@
                 "summary": "更新用户信息",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "用户名",
-                        "name": "username",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "昵称",
-                        "name": "nickname",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "邮箱",
-                        "name": "email",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "密码",
-                        "name": "password",
-                        "in": "formData",
-                        "required": true
+                        "description": "用户信息",
+                        "name": "adminUserUpdateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.AdminUserUpdateParams"
+                        }
                     }
                 ],
                 "responses": {
@@ -965,10 +811,122 @@
                 }
             }
         },
+        "handler.AdminLoginParams": {
+            "type": "object",
+            "required": [
+                "password",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "handler.AdminLoginResp": {
             "type": "object",
             "properties": {
                 "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.AdminSiteUpdateParams": {
+            "type": "object",
+            "required": [
+                "desc",
+                "name",
+                "url"
+            ],
+            "properties": {
+                "desc": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.AdminUserUpdateParams": {
+            "type": "object",
+            "required": [
+                "email",
+                "nickname",
+                "password",
+                "username"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 2
+                },
+                "password": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 6
+                },
+                "username": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "minLength": 3
+                }
+            }
+        },
+        "handler.ArticleAddParams": {
+            "type": "object",
+            "required": [
+                "content",
+                "desc",
+                "slug",
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.ArticleUpdateParams": {
+            "type": "object",
+            "required": [
+                "content",
+                "desc",
+                "slug",
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -987,6 +945,30 @@
                 }
             }
         },
+        "handler.FriendAddParams": {
+            "type": "object",
+            "required": [
+                "avatar",
+                "name",
+                "url"
+            ],
+            "properties": {
+                "avatar": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 32
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "handler.FriendListResp": {
             "type": "object",
             "properties": {
@@ -998,6 +980,63 @@
                     "items": {
                         "$ref": "#/definitions/model.Friend"
                     }
+                }
+            }
+        },
+        "handler.FriendUpdateParams": {
+            "type": "object",
+            "properties": {
+                "avatar": {
+                    "type": "string"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "visible": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "handler.InitParams": {
+            "type": "object",
+            "required": [
+                "email",
+                "name",
+                "nickname",
+                "password",
+                "url",
+                "username"
+            ],
+            "properties": {
+                "desc": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -16,10 +16,89 @@ definitions:
         description: Valid is true if Time is not NULL
         type: boolean
     type: object
+  handler.AdminLoginParams:
+    properties:
+      password:
+        type: string
+      username:
+        type: string
+    required:
+    - password
+    - username
+    type: object
   handler.AdminLoginResp:
     properties:
       token:
         type: string
+    type: object
+  handler.AdminSiteUpdateParams:
+    properties:
+      desc:
+        type: string
+      icon:
+        type: string
+      name:
+        type: string
+      url:
+        type: string
+    required:
+    - desc
+    - name
+    - url
+    type: object
+  handler.AdminUserUpdateParams:
+    properties:
+      email:
+        type: string
+      nickname:
+        maxLength: 32
+        minLength: 2
+        type: string
+      password:
+        maxLength: 32
+        minLength: 6
+        type: string
+      username:
+        maxLength: 32
+        minLength: 3
+        type: string
+    required:
+    - email
+    - nickname
+    - password
+    - username
+    type: object
+  handler.ArticleAddParams:
+    properties:
+      content:
+        type: string
+      desc:
+        type: string
+      slug:
+        type: string
+      title:
+        type: string
+    required:
+    - content
+    - desc
+    - slug
+    - title
+    type: object
+  handler.ArticleUpdateParams:
+    properties:
+      content:
+        type: string
+      desc:
+        type: string
+      slug:
+        type: string
+      title:
+        type: string
+    required:
+    - content
+    - desc
+    - slug
+    - title
     type: object
   handler.ArticlesListResp:
     properties:
@@ -30,6 +109,23 @@ definitions:
       count:
         type: integer
     type: object
+  handler.FriendAddParams:
+    properties:
+      avatar:
+        type: string
+      desc:
+        maxLength: 256
+        type: string
+      name:
+        maxLength: 32
+        type: string
+      url:
+        type: string
+    required:
+    - avatar
+    - name
+    - url
+    type: object
   handler.FriendListResp:
     properties:
       count:
@@ -38,6 +134,45 @@ definitions:
         items:
           $ref: '#/definitions/model.Friend'
         type: array
+    type: object
+  handler.FriendUpdateParams:
+    properties:
+      avatar:
+        type: string
+      desc:
+        type: string
+      name:
+        type: string
+      url:
+        type: string
+      visible:
+        type: boolean
+    type: object
+  handler.InitParams:
+    properties:
+      desc:
+        type: string
+      email:
+        type: string
+      icon:
+        type: string
+      name:
+        type: string
+      nickname:
+        type: string
+      password:
+        type: string
+      url:
+        type: string
+      username:
+        type: string
+    required:
+    - email
+    - name
+    - nickname
+    - password
+    - url
+    - username
     type: object
   handler.RespUserInfo:
     properties:
@@ -128,16 +263,12 @@ paths:
     post:
       description: 管理员使用用户名和密码进行登录，若登录成功，返回token
       parameters:
-      - description: 用户名或邮箱
-        in: formData
-        name: username
+      - description: 登录凭据
+        in: body
+        name: adminLoginParams
         required: true
-        type: string
-      - description: 密码
-        in: formData
-        name: password
-        required: true
-        type: string
+        schema:
+          $ref: '#/definitions/handler.AdminLoginParams'
       responses:
         "200":
           description: 登录成功
@@ -163,25 +294,12 @@ paths:
     put:
       description: 更新站点的名称、URL、描述和图标
       parameters:
-      - description: 站点名称
-        in: formData
-        name: name
+      - description: 站点信息
+        in: body
+        name: adminSiteUpdateParams
         required: true
-        type: string
-      - description: 站点URL
-        in: formData
-        name: url
-        required: true
-        type: string
-      - description: 站点描述
-        in: formData
-        name: desc
-        required: true
-        type: string
-      - description: 站点图标(base64格式)
-        in: formData
-        name: icon
-        type: string
+        schema:
+          $ref: '#/definitions/handler.AdminSiteUpdateParams'
       responses:
         "200":
           description: 操作成功, 部分主题可能需重新部署生效
@@ -294,21 +412,12 @@ paths:
         name: slug
         required: true
         type: string
-      - description: 文章标题
-        in: formData
-        name: title
+      - description: 文章参数
+        in: body
+        name: articleAddParams
         required: true
-        type: string
-      - description: 文章描述
-        in: formData
-        name: desc
-        required: true
-        type: string
-      - description: 文章内容
-        in: formData
-        name: content
-        required: true
-        type: string
+        schema:
+          $ref: '#/definitions/handler.ArticleAddParams'
       responses:
         "200":
           description: 操作成功
@@ -335,21 +444,12 @@ paths:
         name: slug
         required: true
         type: string
-      - description: 文章的标题
-        in: formData
-        name: title
+      - description: 文章更新参数
+        in: body
+        name: articleUpdateParams
         required: true
-        type: string
-      - description: 文章的描述
-        in: formData
-        name: desc
-        required: true
-        type: string
-      - description: 文章的内容
-        in: formData
-        name: content
-        required: true
-        type: string
+        schema:
+          $ref: '#/definitions/handler.ArticleUpdateParams'
       responses:
         "200":
           description: 更新成功
@@ -407,25 +507,12 @@ paths:
       - application/json
       description: 添加友情链接
       parameters:
-      - description: 名称
-        in: formData
-        name: name
+      - description: 友情链接信息
+        in: body
+        name: friendAddParams
         required: true
-        type: string
-      - description: 图标URL
-        in: formData
-        name: avatar
-        required: true
-        type: string
-      - description: URL
-        in: formData
-        name: url
-        required: true
-        type: string
-      - description: 描述
-        in: formData
-        name: desc
-        type: string
+        schema:
+          $ref: '#/definitions/handler.FriendAddParams'
       produces:
       - application/json
       responses:
@@ -491,34 +578,12 @@ paths:
       - application/json
       description: 更新友情链接
       parameters:
-      - description: 友情链接的ID
-        in: path
-        name: id
+      - description: 更新友情链接参数
+        in: body
+        name: friendUpdateParams
         required: true
-        type: integer
-      - description: 名称
-        in: formData
-        name: name
-        required: true
-        type: string
-      - description: 图标URL
-        in: formData
-        name: avatar
-        required: true
-        type: string
-      - description: URL
-        in: formData
-        name: url
-        required: true
-        type: string
-      - description: 描述
-        in: formData
-        name: desc
-        type: string
-      - description: 是否可见
-        in: formData
-        name: visible
-        type: boolean
+        schema:
+          $ref: '#/definitions/handler.FriendUpdateParams'
       produces:
       - application/json
       responses:
@@ -569,46 +634,18 @@ paths:
       - 友情链接
   /init:
     post:
+      consumes:
+      - application/json
       description: 使用给定的参数初始化站点
       parameters:
-      - description: 用户名
-        in: formData
-        name: username
+      - description: 初始化参数
+        in: body
+        name: initParams
         required: true
-        type: string
-      - description: 昵称
-        in: formData
-        name: nickname
-        required: true
-        type: string
-      - description: 邮箱
-        in: formData
-        name: email
-        required: true
-        type: string
-      - description: 密码
-        in: formData
-        name: password
-        required: true
-        type: string
-      - description: 站点名称
-        in: formData
-        name: name
-        required: true
-        type: string
-      - description: 站点URL
-        in: formData
-        name: url
-        required: true
-        type: string
-      - description: 站点描述
-        in: formData
-        name: desc
-        type: string
-      - description: 站点图标(base64格式)
-        in: formData
-        name: icon
-        type: string
+        schema:
+          $ref: '#/definitions/handler.InitParams'
+      produces:
+      - application/json
       responses:
         "200":
           description: 初始化成功
@@ -660,26 +697,12 @@ paths:
     put:
       description: 管理员更新用户信息
       parameters:
-      - description: 用户名
-        in: path
-        name: username
+      - description: 用户信息
+        in: body
+        name: adminUserUpdateParams
         required: true
-        type: string
-      - description: 昵称
-        in: formData
-        name: nickname
-        required: true
-        type: string
-      - description: 邮箱
-        in: formData
-        name: email
-        required: true
-        type: string
-      - description: 密码
-        in: formData
-        name: password
-        required: true
-        type: string
+        schema:
+          $ref: '#/definitions/handler.AdminUserUpdateParams'
       responses:
         "200":
           description: OK

--- a/packages/dashboard/src/pages/article/create.tsx
+++ b/packages/dashboard/src/pages/article/create.tsx
@@ -59,7 +59,12 @@ const CreateArticlePage = () => {
 
     const res = await useApi(`/api/article/${slug}`, {
       method: "POST",
-      body: formData,
+      data: {
+        title,
+        desc,
+        slug,
+        content,
+      },
     });
 
     const data = await res.json().catch((err) => {

--- a/packages/dashboard/src/pages/article/edit/index.tsx
+++ b/packages/dashboard/src/pages/article/edit/index.tsx
@@ -91,14 +91,14 @@ const EditArticlePage = () => {
     const { title, desc, slug } = articleMeta;
     const content = vd?.getValue() || "";
 
-    const formData = new FormData();
-    formData.append("title", title);
-    formData.append("desc", desc);
-    formData.append("content", content);
-
     const res = await useApi(`/api/article/${slug}`, {
       method: "PUT",
-      body: formData,
+      data: {
+        title,
+        desc,
+        slug,
+        content,
+      },
     });
 
     const data = await res.json().catch((err) => {

--- a/packages/dashboard/src/pages/friend/index.tsx
+++ b/packages/dashboard/src/pages/friend/index.tsx
@@ -47,18 +47,11 @@ const FriendPage = () => {
   const handleDrawerSubmit = async (values: Friend) => {
     let updatedFriends: Friend[] = [];
 
-    const formData = new FormData();
-    formData.append("name", values.name);
-    formData.append("desc", values.desc);
-    formData.append("url", values.url);
-    formData.append("avatar", values.avatar);
-    formData.append("visible", values.visible ? "true" : "false");
-
     try {
       if (currentFriend !== undefined) {
         await useApi(`/api/friend/${currentFriend?.id}`, {
           method: "PUT",
-          body: formData,
+          data: values,
         });
         updatedFriends = friends.map((friend) =>
           friend.id === currentFriend?.id ? { ...friend, ...values } : friend,
@@ -66,7 +59,7 @@ const FriendPage = () => {
       } else {
         await useApi(`/api/friend`, {
           method: "POST",
-          body: formData,
+          data: values,
         });
         updatedFriends = [...friends, values];
       }

--- a/packages/dashboard/src/pages/init.tsx
+++ b/packages/dashboard/src/pages/init.tsx
@@ -44,19 +44,9 @@ const InitPage = () => {
   const handleSubmit = async (values: Init) => {
     formRef.current?.validateFields();
 
-    const formData = new FormData();
-
-    formData.append("name", values.name);
-    formData.append("url", values.url);
-    formData.append("desc", values.desc);
-    formData.append("email", values.email);
-    formData.append("username", values.username);
-    formData.append("nickname", values.nickname);
-    formData.append("password", values.password);
-
     const res = await useApi("/api/init", {
       method: "POST",
-      body: formData,
+      data: values,
     });
 
     const data = await res.json();

--- a/packages/dashboard/src/pages/login.tsx
+++ b/packages/dashboard/src/pages/login.tsx
@@ -29,7 +29,7 @@ const LoginPage = () => {
 
     const res = await useApi("/api/admin/login", {
       method: "POST",
-      body: formData,
+      data: values,
     });
 
     const data = await res.json();

--- a/packages/dashboard/src/pages/site/index.tsx
+++ b/packages/dashboard/src/pages/site/index.tsx
@@ -41,15 +41,9 @@ const SitePage = () => {
   }, []);
 
   const handleSubmit = async (value: Site) => {
-    const formData = new FormData();
-
-    formData.append("name", value.name);
-    formData.append("url", value.url);
-    formData.append("desc", value.desc);
-
     useApi("/api/admin/site", {
       method: "PUT",
-      body: formData,
+      data: value,
     })
       .then((res) => res.json())
       .then(() => {

--- a/packages/dashboard/src/utils/fetcher.ts
+++ b/packages/dashboard/src/utils/fetcher.ts
@@ -12,7 +12,7 @@ const useApi = async (
   const token = localStorage.getItem("token");
 
   let headers =
-    opts?.options && opts.options.headers
+    opts?.options?.headers
       ? new Headers(opts.options.headers)
       : new Headers();
 
@@ -30,6 +30,13 @@ const useApi = async (
 
   if (res.status === 401) {
     localStorage.removeItem("token");
+
+    message.open({
+      type: "warning",
+      content: "请登录"
+    })
+
+    history.push("/login")
   }
 
   return res;

--- a/packages/dashboard/src/utils/fetcher.ts
+++ b/packages/dashboard/src/utils/fetcher.ts
@@ -1,32 +1,35 @@
 import { message } from "antd";
 import { history } from "umi";
 
-const useApi = async (url: string | URL | Request, options?: RequestInit) => {
+const useApi = async (
+  url: string | URL | Request,
+  opts?: {
+    method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD";
+    data?: any;
+    options?: RequestInit;
+  },
+) => {
   const token = localStorage.getItem("token");
 
-  if (token) {
-    const headers =
-      options && options.headers ? new Headers(options.headers) : new Headers();
+  let headers =
+    opts?.options && opts.options.headers
+      ? new Headers(opts.options.headers)
+      : new Headers();
 
-    headers.append("Authorization", token);
+  headers.append("Authorization", token!);
+  headers.append("Content-Type", "application/json");
 
-    options = {
-      ...options,
-      headers,
-    };
-  }
+  const requestOptions: RequestInit = {
+    method: opts?.method || "GET",
+    headers,
+    body: opts?.data ? JSON.stringify(opts.data) : undefined,
+    ...opts?.options,
+  };
 
-  const res = await fetch(url, options);
+  const res = await fetch(url, requestOptions);
 
-  if (res.status == 401) {
+  if (res.status === 401) {
     localStorage.removeItem("token");
-    if (history.location.pathname != "/login") {
-      message.open({
-        type: "info",
-        content: "登录信息已过期，请重新登录",
-      });
-      history.push("/login");
-    }
   }
 
   return res;

--- a/packages/themekit/package.json
+++ b/packages/themekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reblog/themekit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "reblog themekit",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/themekit/src/index.ts
+++ b/packages/themekit/src/index.ts
@@ -1,6 +1,6 @@
 import { Config } from "./config";
 import { Article, ArticleList, Friend, Site, User } from "./types";
-import { Api, objToFormData } from "./utils";
+import { Api } from "./utils";
 
 class ThemeKit {
   private api: Api;
@@ -40,8 +40,7 @@ class ThemeKit {
   }
 
   public async addFriend(friend: Friend) {
-    const data = objToFormData(friend);
-    const res = await this.api.post<Friend>("/api/friend", data);
+    const res = await this.api.post<Friend>("/api/friend", friend);
 
     return res;
   }

--- a/packages/themekit/src/utils/api.ts
+++ b/packages/themekit/src/utils/api.ts
@@ -11,7 +11,7 @@ export class Api {
     return await useApi<T>(this.baseURL + url, options);
   }
 
-  async post<T>(url: string, body: FormData, options?: RequestInit) {
+  async post<T>(url: string, body: any, options?: RequestInit) {
     return await useApi<T>(this.baseURL + url, {
       method: "POST",
       body,

--- a/packages/themekit/src/utils/form.ts
+++ b/packages/themekit/src/utils/form.ts
@@ -1,9 +1,0 @@
-export function objToFormData(obj: any): FormData {
-  const formData = new FormData();
-  for (const key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      formData.append(key, obj[key]);
-    }
-  }
-  return formData;
-}

--- a/packages/themekit/src/utils/index.ts
+++ b/packages/themekit/src/utils/index.ts
@@ -1,2 +1,1 @@
 export * from "./api";
-export * from "./form";

--- a/server/handler/admin_login.go
+++ b/server/handler/admin_login.go
@@ -20,11 +20,10 @@ type AdminLoginResp struct {
 //	@Summary		登录
 //	@Description	管理员使用用户名和密码进行登录，若登录成功，返回token
 //	@Tags			站点管理
-//	@Param			username	formData	string								true	"用户名或邮箱"
-//	@Param			password	formData	string								true	"密码"
-//	@Success		200			{object}	common.Resp{data=AdminLoginResp}	"登录成功"
-//	@Failure		400			{object}	common.Resp							"缺少必要参数"
-//	@Failure		401			{object}	common.Resp							"用户名或密码错误"
+//	@Param			adminLoginParams	body		AdminLoginParams					true	"登录凭据"
+//	@Success		200					{object}	common.Resp{data=AdminLoginResp}	"登录成功"
+//	@Failure		400					{object}	common.Resp							"缺少必要参数"
+//	@Failure		401					{object}	common.Resp							"用户名或密码错误"
 //	@Router			/admin/login [post]
 func AdminLogin(app *core.App, router fiber.Router) {
 	router.Post("/login", func(c fiber.Ctx) error {

--- a/server/handler/admin_site_update.go
+++ b/server/handler/admin_site_update.go
@@ -17,12 +17,9 @@ type AdminSiteUpdateParams struct {
 //	@Summary		更新站点信息
 //	@Description	更新站点的名称、URL、描述和图标
 //	@Tags			站点管理
-//	@Param			name	formData	string		true	"站点名称"
-//	@Param			url		formData	string		true	"站点URL"
-//	@Param			desc	formData	string		true	"站点描述"
-//	@Param			icon	formData	string		false	"站点图标(base64格式)"
-//	@Success		200		{object}	common.Resp	"操作成功, 部分主题可能需重新部署生效"
-//	@Failure		400		{object}	common.Resp	"缺少参数"
+//	@Param			adminSiteUpdateParams	body		AdminSiteUpdateParams	true	"站点信息"
+//	@Success		200						{object}	common.Resp				"操作成功, 部分主题可能需重新部署生效"
+//	@Failure		400						{object}	common.Resp				"缺少参数"
 //	@Security		ApiKeyAuth
 //	@Router			/admin/site [PUT]
 func AdminSiteUpdate(app *core.App, router fiber.Router) {

--- a/server/handler/admin_user_update.go
+++ b/server/handler/admin_user_update.go
@@ -17,12 +17,9 @@ type AdminUserUpdateParams struct {
 //	@Summary		更新用户信息
 //	@Description	管理员更新用户信息
 //	@Tags			站点管理
-//	@Param			username	path		string	true	"用户名"
-//	@Param			nickname	formData	string	true	"昵称"
-//	@Param			email		formData	string	true	"邮箱"
-//	@Param			password	formData	string	true	"密码"
-//	@Success		200			{object}	common.Resp
-//	@Failure		400			{object}	common.Resp
+//	@Param			adminUserUpdateParams	body		AdminUserUpdateParams	true	"用户信息"
+//	@Success		200						{object}	common.Resp
+//	@Failure		400						{object}	common.Resp
 //	@Router			/user/{username} [put]
 func AdminUserUpdate(app *core.App, router fiber.Router) {
 	router.Put("/user/:username", func(c fiber.Ctx) error {

--- a/server/handler/article_add.go
+++ b/server/handler/article_add.go
@@ -19,13 +19,11 @@ type ArticleAddParams struct {
 //	@Summary		添加文章
 //	@Description	添加一篇新的文章
 //	@Tags			文章
-//	@Param			slug	path		string		true	"文章slug"
-//	@Param			title	formData	string		true	"文章标题"
-//	@Param			desc	formData	string		true	"文章描述"
-//	@Param			content	formData	string		true	"文章内容"
-//	@Success		200		{object}	common.Resp	"操作成功"
-//	@Failure		400		{object}	common.Resp	"缺少必要参数"
-//	@Failure		409		{object}	common.Resp	"slug已被其他文章使用"
+//	@Param			slug				path		string				true	"文章slug"
+//	@Param			articleAddParams	body		ArticleAddParams	true	"文章参数"
+//	@Success		200					{object}	common.Resp			"操作成功"
+//	@Failure		400					{object}	common.Resp			"缺少必要参数"
+//	@Failure		409					{object}	common.Resp			"slug已被其他文章使用"
 //	@Security		ApiKeyAuth
 //	@Router			/article/{slug} [post]
 func ArticleAdd(app *core.App, router fiber.Router) {

--- a/server/handler/article_delete.go
+++ b/server/handler/article_delete.go
@@ -29,6 +29,10 @@ func ArticleDelete(app *core.App, router fiber.Router) {
 
 		params.Slug = c.Params("slug")
 
+		if common.IsEmpty(params.Slug) {
+			return common.RespFail(c, http.StatusBadRequest, "缺少slug", nil)
+		}
+
 		article, err := a.Where(a.Slug.Eq(params.Slug)).First()
 
 		if article == nil {

--- a/server/handler/article_delete.go
+++ b/server/handler/article_delete.go
@@ -26,9 +26,8 @@ func ArticleDelete(app *core.App, router fiber.Router) {
 		a := app.Query().Article
 
 		var params ArticleDeleteParams
-		if isValid, resp := common.Param(app, c, &params); !isValid {
-			return resp
-		}
+
+		params.Slug = c.Params("slug")
 
 		article, err := a.Where(a.Slug.Eq(params.Slug)).First()
 

--- a/server/handler/article_update.go
+++ b/server/handler/article_update.go
@@ -19,13 +19,11 @@ type ArticleUpdateParams struct {
 //	@Summary		更新文章
 //	@Description	根据slug更新文章的标题、描述和内容
 //	@Tags			文章
-//	@Param			slug	path		string		true	"文章的slug"
-//	@Param			title	formData	string		true	"文章的标题"
-//	@Param			desc	formData	string		true	"文章的描述"
-//	@Param			content	formData	string		true	"文章的内容"
-//	@Success		200		{object}	common.Resp	"更新成功"
-//	@Failure		400		{object}	common.Resp	"缺失参数"
-//	@Failure		404		{object}	common.Resp	"未知的文章"
+//	@Param			slug				path		string				true	"文章的slug"
+//	@Param			articleUpdateParams	body		ArticleUpdateParams	true	"文章更新参数"
+//	@Success		200					{object}	common.Resp			"更新成功"
+//	@Failure		400					{object}	common.Resp			"缺失参数"
+//	@Failure		404					{object}	common.Resp			"未知的文章"
 //	@Security		ApiKeyAuth
 //	@Router			/article/{slug} [put]
 func ArticleUpdate(app *core.App, router fiber.Router) {

--- a/server/handler/friend_add.go
+++ b/server/handler/friend_add.go
@@ -20,13 +20,10 @@ type FriendAddParams struct {
 //	@Tags			友情链接
 //	@Accept			json
 //	@Produce		json
-//	@Param			name	formData	string							true	"名称"
-//	@Param			avatar	formData	string							true	"图标URL"
-//	@Param			url		formData	string							true	"URL"
-//	@Param			desc	formData	string							false	"描述"
-//	@Success		200		{object}	common.Resp{data=model.Friend}	"添加友情链接成功"
-//	@Failure		400		{object}	common.Resp						"请求参数错误"
-//	@Failure		500		{object}	common.Resp						"服务器内部错误"
+//	@Param			friendAddParams	body		FriendAddParams					true	"友情链接信息"
+//	@Success		200				{object}	common.Resp{data=model.Friend}	"添加友情链接成功"
+//	@Failure		400				{object}	common.Resp						"请求参数错误"
+//	@Failure		500				{object}	common.Resp						"服务器内部错误"
 //	@Security		ApiKeyAuth
 //	@Router			/friend [post]
 func FriendAdd(app *core.App, router fiber.Router) {

--- a/server/handler/friend_update.go
+++ b/server/handler/friend_update.go
@@ -22,15 +22,10 @@ type FriendUpdateParams struct {
 //	@Tags			友情链接
 //	@Accept			json
 //	@Produce		json
-//	@Param			id		path		integer			true	"友情链接的ID"
-//	@Param			name	formData	string			true	"名称"
-//	@Param			avatar	formData	string			true	"图标URL"
-//	@Param			url		formData	string			true	"URL"
-//	@Param			desc	formData	string			false	"描述"
-//	@Param			visible	formData	bool			false	"是否可见"
-//	@Success		200		{object}	common.Resp{}	"更新友情链接成功"
-//	@Failure		400		{object}	common.Resp		"请求参数错误"
-//	@Failure		500		{object}	common.Resp		"服务器内部错误"
+//	@Param			friendUpdateParams	body		FriendUpdateParams	true	"更新友情链接参数"
+//	@Success		200					{object}	common.Resp{}		"更新友情链接成功"
+//	@Failure		400					{object}	common.Resp			"请求参数错误"
+//	@Failure		500					{object}	common.Resp			"服务器内部错误"
 //	@Security		ApiKeyAuth
 //	@Router			/friend/{id} [put]
 func FriendUpdate(app *core.App, router fiber.Router) {

--- a/server/handler/init.go
+++ b/server/handler/init.go
@@ -30,14 +30,9 @@ type InitParams struct {
 //	@Summary		初始化站点
 //	@Description	使用给定的参数初始化站点
 //	@Tags			站点管理
-//	@Param			username	formData	string		true	"用户名"
-//	@Param			nickname	formData	string		true	"昵称"
-//	@Param			email		formData	string		true	"邮箱"
-//	@Param			password	formData	string		true	"密码"
-//	@Param			name		formData	string		true	"站点名称"
-//	@Param			url			formData	string		true	"站点URL"
-//	@Param			desc		formData	string		false	"站点描述"
-//	@Param			icon		formData	string		false	"站点图标(base64格式)"
+//	@Accept			json
+//	@Produce		json
+//	@Param			initParams	body		InitParams	true	"初始化参数"
 //	@Success		200			{object}	common.Resp	"初始化成功"
 //	@Failure		400			{object}	common.Resp	"无效的邮箱或URL"
 //	@Failure		403			{object}	common.Resp	"此站点已初始化"


### PR DESCRIPTION
后端虽兼容json与formData两种请求体，但dashboard和themekit默认使用formData，但formData疑似会导致vercel环境下405错误，此pr将dashboard与themekit中的请求体改为json。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 改进了API文档，采用更结构化的请求参数定义，提升了API的清晰度和可维护性。
	- 新增多个请求参数结构，简化API调用的复杂性。
	- 更新了`useApi`函数接口，增强了请求参数的灵活性和可读性。

- **修复**
	- 修改多个组件的API请求结构，确保数据传输的清晰性和一致性。

- **版本更新**
	- 更新`@reblog/themekit`包的版本号，从`0.1.3`升级到`0.1.4`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->